### PR TITLE
PT-428 matchmaking shell script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+matchmake.properties

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Fill out all values with the values we've sent you.
 
 Then run
 > ./matchmake.sh
+
+DOES NOT WORK ON MAC YET

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# matchmaking-example
+# How to use
+
+Copy `matchmake.ex.properties` to `matchmake.properties`.
+Fill out all values with the values we've sent you.
+
+Then run
+> ./matchmake.sh

--- a/matchmake.ex.properties
+++ b/matchmake.ex.properties
@@ -1,0 +1,11 @@
+api.base=PLAYT_API_ENDPOINT
+
+game.id=GAME_ID_TO_MATCHMAKE
+game.url=GAME_URL
+game.client.id=GAME_CLIENT_ID
+game.client.secret=GAME_CLIENT_SECRET
+
+user.client.id=AUTH_CLIENT_ID
+user.client.secret=AUTH_CLIENT_SECRET
+user.login=AUTH_USER_NAME
+user.password=AUTH_USER_PASSWORD

--- a/matchmake.sh
+++ b/matchmake.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 echo "This script will trigger a matchmaking with the given parameters and return a playerToken. This token can be used by the game server to communicate with our api."
 
-file="./matchmake.properties"
+file="matchmake.properties"
 
 if [ -f "$file" ]
 then
+  
   echo "$file found."
-  # Read properties file and export vars - replaces . with _ for keys
-  source <(grep -v '^ *#' $file | grep '[^ ] *=' | awk '{split($0,a,"="); print gensub(/\./, "_", "g", a[1]) "=" a[2]}')
+  api_base=$(sed -rn 's/^api.base=([^\n]+)$/\1/p' $file)
+  game_id=$(sed -rn 's/^game.id=([^\n]+)$/\1/p' $file)
+  game_url=$(sed -rn 's/^game.url=([^\n]+)$/\1/p' $file)
+  game_client_id=$(sed -rn 's/^game.client.id=([^\n]+)$/\1/p' $file)
+  game_client_secret=$(sed -rn 's/^game.client.secret=([^\n]+)$/\1/p' $file)
+  user_client_id=$(sed -rn 's/^user.client.id=([^\n]+)$/\1/p' $file)
+  user_client_secret=$(sed -rn 's/^user.client.secret=([^\n]+)$/\1/p' $file)
+  user_login=$(sed -rn 's/^user.login=([^\n]+)$/\1/p' $file)
+  user_password=$(sed -rn 's/^user.password=([^\n]+)$/\1/p' $file)
   
   echo "Api Base          = " ${api_base}
   echo "Game Id           = " ${game_id}
@@ -49,7 +57,7 @@ ticketId=${ticketIdPairDirty//\"/}
 printf "ticketId for user: $ticketId\n\n"
 
 # Check for matchmaking status and only return the playerToken, once the status is 'matched' or 'notMatched'
-clear
+#clear
 counter=0
 sleepTime=5
 for (( ; ; ))

--- a/matchmake.sh
+++ b/matchmake.sh
@@ -5,7 +5,6 @@ file="matchmake.properties"
 
 if [ -f "$file" ]
 then
-  
   echo "$file found."
   api_base=$(sed -rn 's/^api.base=([^\n]+)$/\1/p' $file)
   game_id=$(sed -rn 's/^game.id=([^\n]+)$/\1/p' $file)
@@ -78,11 +77,13 @@ do
 
     if [[ $tickerStatus == *matched* ]]
     then
-        printf "Found a match - playerToken: $playerToken\n$launchGame"
+        printf "Found a match - playerToken: $playerToken\n"
+        echo $launchGame
         exit 0
     elif [[ $tickerStatus == *notMatched* ]]
     then
-        printf "Not matched, you can play anyway - playerToken: $playerToken\n$launchGame"
+        printf "Not matched, you can play anyway - playerToken: $playerToken\n"
+        echo $launchGame
         exit 0        
     fi
 

--- a/matchmake.sh
+++ b/matchmake.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+echo "This script will trigger a matchmaking with the given parameters and return a playerToken. This token can be used by the game server to communicate with our api."
+
+file="./matchmake.properties"
+
+if [ -f "$file" ]
+then
+  echo "$file found."
+  # Read properties file and export vars - replaces . with _ for keys
+  source <(grep -v '^ *#' $file | grep '[^ ] *=' | awk '{split($0,a,"="); print gensub(/\./, "_", "g", a[1]) "=" a[2]}')
+  
+  echo "Api Base          = " ${api_base}
+  echo "Game Id           = " ${game_id}
+  echo "Game URL          = " ${game_url}
+  echo "Game ClientId     = " ${game_client_id}
+  echo "Game ClientSecret = " ${game_client_secret}
+  echo "User ClientId     = " ${user_client_id}
+  echo "User ClientSecret = " ${user_client_secret}
+  echo "User Login        = " ${user_login}
+  echo "User Password     = " ${user_password}
+else
+  echo "$file not found."
+  exit 1
+fi
+
+# Get accessToken for user to be used in matchmaking
+accessTokenDirty=$(curl -s --location --request POST "${api_base}/auth/authorize" \
+--header 'Content-Type: application/json' \
+--data-raw "{
+    \"grantType\": \"password\",
+    \"username\": \"$user_login\",
+    \"password\": \"$user_password\",
+    \"clientId\": \"$user_client_id\",
+    \"clientSecret\": \"$user_client_secret\"
+}" | grep -oP '"accessToken": *\K"[^"]*"')
+accessToken=${accessTokenDirty//\"/}
+printf "accessToken for user:\n$accessToken\n\n"
+
+# Now start matchmaking
+ticketIdPairDirty=$(curl -s --location --request POST "${api_base}/matchmaking/search" \
+--header "Authorization: Bearer $accessToken" \
+--header 'Content-Type: application/json' \
+--data-raw "{
+    \"gameId\": \"$game_id\",
+    \"gameMode\": \"1_vs_1\",
+    \"denominationTier\": \"denomination_tier_0\"
+}" | grep -oP '"ticketId": *\K"[^"]*"')
+ticketId=${ticketIdPairDirty//\"/}
+printf "ticketId for user: $ticketId\n\n"
+
+# Check for matchmaking status and only return the playerToken, once the status is 'matched' or 'notMatched'
+clear
+counter=0
+sleepTime=5
+for (( ; ; ))
+do
+    a=$(( counter * sleepTime ))
+    printf "${a} sec.\twaiting for ticket status update for ticketId $ticketId [ hit CTRL+C to stop]\n"
+
+    # Check for ticket status
+    ticketStatusResponse=$(curl -s --location --request GET "${api_base}//matchmaking/ticket/$ticketId" --header "Authorization: Bearer $accessToken")
+    tickerStatusDirty=$(echo $ticketStatusResponse | grep -oP '"status": *\K"[^"]*"')
+    tickerStatus=${tickerStatusDirty//\"/}
+    printf "Ticket Status: $tickerStatus\n"
+
+    playerTokenDirty=$(echo $ticketStatusResponse | grep -oP '"playerToken": *\K"[^"]*"')
+    playerToken=${playerTokenDirty//\"/}
+
+    launchGame=$(echo Launch game: $game_url?playerToken=$playerToken)
+
+    if [[ $tickerStatus == *matched* ]]
+    then
+        printf "Found a match - playerToken: $playerToken\n$launchGame"
+        exit 0
+    elif [[ $tickerStatus == *notMatched* ]]
+    then
+        printf "Not matched, you can play anyway - playerToken: $playerToken\n$launchGame"
+        exit 0        
+    fi
+
+    ((counter++))
+    sleep 5
+done


### PR DESCRIPTION
Create a script that:

- logs in a given player user
- caches his access token
- enqueues the player the the matchmaker with the given game data
- listens to the matchmaking ticket status for this player
- reacts to the ticket status, when it is `matched` or `notMatched` the matchmaker is done
- reads the `playerToken` and builds a launchable url 